### PR TITLE
Fix Travis Codestyle with CMS: #7173

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -729,7 +729,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	{
 		$charset = $this->utf8mb4 ? 'utf8mb4' : 'utf8';
 
-		return 'ALTER DATABASE ' . $this->quoteName($dbName) . ' CHARACTER SET `' . $charset .'`';
+		return 'ALTER DATABASE ' . $this->quoteName($dbName) . ' CHARACTER SET `' . $charset . '`';
 	}
 
 	/**
@@ -765,7 +765,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			foreach ($columns as $column)
 			{
 				// Make sure we are redefining only columns which do support a collation
-				$col = (object)$column;
+				$col = (object) $column;
 
 				if (empty($col->Collation))
 				{
@@ -1077,6 +1077,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * class name.
 	 *
 	 * @return  string
+	 *
 	 * @since   CMS 3.5.0
 	 */
 	public function getName()
@@ -1097,6 +1098,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * be returned instead.
 	 *
 	 * @return  string
+	 *
 	 * @since   CMS 3.5.0
 	 */
 	public function getServerType()

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -498,6 +498,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	 * libmysql supports utf8mb4 since 5.5.3 (same version as the MySQL server). mysqlnd supports utf8mb4 since 5.0.9.
 	 *
 	 * @return  boolean
+	 *
 	 * @since   CMS 3.5.0
 	 */
 	private function serverClaimsUtf8mb4Support()

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -939,6 +939,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	 * libmysql supports utf8mb4 since 5.5.3 (same version as the MySQL server). mysqlnd supports utf8mb4 since 5.0.9.
 	 *
 	 * @return  boolean
+	 *
 	 * @since   CMS 3.5.0
 	 */
 	private function serverClaimsUtf8mb4Support()

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -156,8 +156,10 @@ class JFilterInput
 			{
 				// Get the database driver
 				$db = JFactory::getDbo();
+
 				// This trick is required to let the driver determine the utf-8 multibyte support
 				$db->connect();
+
 				// And now we can decide if we should strip USCs
 				$this->stripUSC = $db->hasUTF8mb4Support() ? 0 : 1;
 			}
@@ -228,8 +230,8 @@ class JFilterInput
 		// Strip Unicode Supplementary Characters when requested to do so
 		if ($this->stripUSC)
 		{
-			$source = preg_replace('/[\xF0-\xF7].../s', "\xE2\xAF\x91", $source);
 			// Alternatively: preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xE2\xAF\x91", $source) but it'd be slower.
+			$source = preg_replace('/[\xF0-\xF7].../s', "\xE2\xAF\x91", $source);
 		}
 
 		// Handle the type constraint


### PR DESCRIPTION
```
FILE: /home/travis/build/joomla/joomla-cms/libraries/joomla/filter/input.php
--------------------------------------------------------------------------------
FOUND 3 ERROR(S) AFFECTING 3 LINE(S)
--------------------------------------------------------------------------------
 159 | ERROR | Please consider a blank line preceding your comment
 161 | ERROR | Please consider a blank line preceding your comment
 232 | ERROR | Please consider a blank line preceding your comment
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
FILE: ...ome/travis/build/joomla/joomla-cms/libraries/joomla/database/driver.php
--------------------------------------------------------------------------------
FOUND 4 ERROR(S) AFFECTING 4 LINE(S)
--------------------------------------------------------------------------------
  738 | ERROR | Concat operator must be followed by one space
  774 | ERROR | Cast statements must be followed by a single space; expected
      |       | "(object) $column" but found "(object)$column"
 1085 | ERROR | Return comment requires a blank newline after it
 1105 | ERROR | Return comment requires a blank newline after it
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
FILE: ...vis/build/joomla/joomla-cms/libraries/joomla/database/driver/mysqli.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 941 | ERROR | Return comment requires a blank newline after it
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
FILE: ...avis/build/joomla/joomla-cms/libraries/joomla/database/driver/mysql.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 500 | ERROR | Return comment requires a blank newline after it
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
```

@nikosdion This fixes the Codestyle that travis found. see: https://travis-ci.org/joomla/joomla-cms/jobs/66743020

Thanks :smile: 