### PR TITLE
[CMS PR #35388] Fix bytes and files counter not being updated in UI

### DIFF
--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -76,6 +76,10 @@ Joomla.Update = window.Joomla.Update || {
     Joomla.Update.stat_inbytes = 0;
     Joomla.Update.stat_outbytes = 0;
 
+    document.getElementById('extbytesin').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
+    document.getElementById('extbytesout').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
+    document.getElementById('extfiles').innerText = Joomla.Update.stat_files;
+
     const postData = new FormData();
     postData.append('task', 'startExtract');
     postData.append('password', Joomla.Update.password);

--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -123,13 +123,13 @@ Joomla.Update = window.Joomla.Update || {
     }
 
     // Add data to variables
-    Joomla.Update.stat_inbytes = Joomla.Update.formatBytes(data.bytesIn);
+    Joomla.Update.stat_inbytes = data.bytesIn;
     Joomla.Update.stat_percent = data.percent;
     Joomla.Update.stat_percent = Joomla.Update.stat_percent
       || (100 * (Joomla.Update.stat_inbytes / Joomla.Update.totalsize));
 
     // Update GUI
-    Joomla.Update.stat_outbytes = Joomla.Update.formatBytes(data.bytesOut);
+    Joomla.Update.stat_outbytes = data.bytesOut;
     Joomla.Update.stat_files = data.files;
 
     if (Joomla.Update.stat_percent < 100) {
@@ -144,8 +144,8 @@ Joomla.Update = window.Joomla.Update || {
 
     progressDiv.innerText = `${Joomla.Update.stat_percent.toFixed(1)}%`;
 
-    document.getElementById('extbytesin').innerText = Joomla.Update.stat_inbytes;
-    document.getElementById('extbytesout').innerText = Joomla.Update.stat_outbytes;
+    document.getElementById('extbytesin').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
+    document.getElementById('extbytesout').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
     document.getElementById('extfiles').innerText = Joomla.Update.stat_files;
 
     // This is required so we can get outside the scope of the previous XHR's success handler.

--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -113,9 +113,6 @@ Joomla.Update = window.Joomla.Update || {
 
     const progressDiv = document.getElementById('progress-bar');
     const titleDiv = document.getElementById('update-title');
-    const inbytesSpan = document.getElementById('extbytesin');
-    const outbytesSpan = document.getElementById('extbytesout');
-    const filesSpan = document.getElementById('extfiles');
 
     // Are we done extracting?
     if (data.done) {
@@ -123,9 +120,6 @@ Joomla.Update = window.Joomla.Update || {
       progressDiv.style.width = '100%';
       progressDiv.setAttribute('aria-valuenow', 100);
       titleDiv.innerHTML = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
-      inbytesSpan.innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
-      outbytesSpan.innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
-      filesSpan.innerText = Joomla.Update.stat_files;
 
       Joomla.Update.finalizeUpdate();
 
@@ -154,9 +148,9 @@ Joomla.Update = window.Joomla.Update || {
 
     progressDiv.innerText = `${Joomla.Update.stat_percent.toFixed(1)}%`;
 
-    inbytesSpan.innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
-    outbytesSpan.innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
-    filesSpan.innerText = Joomla.Update.stat_files;
+    document.getElementById('extbytesin').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
+    document.getElementById('extbytesout').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
+    document.getElementById('extfiles').innerText = Joomla.Update.stat_files;
 
     // This is required so we can get outside the scope of the previous XHR's success handler.
     window.setTimeout(() => {

--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -114,18 +114,6 @@ Joomla.Update = window.Joomla.Update || {
     const progressDiv = document.getElementById('progress-bar');
     const titleDiv = document.getElementById('update-title');
 
-    // Are we done extracting?
-    if (data.done) {
-      progressDiv.classList.add('bg-success');
-      progressDiv.style.width = '100%';
-      progressDiv.setAttribute('aria-valuenow', 100);
-      titleDiv.innerHTML = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
-
-      Joomla.Update.finalizeUpdate();
-
-      return;
-    }
-
     // Add data to variables
     Joomla.Update.stat_inbytes = data.bytesIn;
     Joomla.Update.stat_percent = data.percent;
@@ -151,6 +139,18 @@ Joomla.Update = window.Joomla.Update || {
     document.getElementById('extbytesin').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
     document.getElementById('extbytesout').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
     document.getElementById('extfiles').innerText = Joomla.Update.stat_files;
+
+    // Are we done extracting?
+    if (data.done) {
+      progressDiv.classList.add('bg-success');
+      progressDiv.style.width = '100%';
+      progressDiv.setAttribute('aria-valuenow', 100);
+      titleDiv.innerHTML = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
+
+      Joomla.Update.finalizeUpdate();
+
+      return;
+    }
 
     // This is required so we can get outside the scope of the previous XHR's success handler.
     window.setTimeout(() => {

--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -113,6 +113,9 @@ Joomla.Update = window.Joomla.Update || {
 
     const progressDiv = document.getElementById('progress-bar');
     const titleDiv = document.getElementById('update-title');
+    const inbytesSpan = document.getElementById('extbytesin');
+    const outbytesSpan = document.getElementById('extbytesout');
+    const filesSpan = document.getElementById('extfiles');
 
     // Are we done extracting?
     if (data.done) {
@@ -120,6 +123,9 @@ Joomla.Update = window.Joomla.Update || {
       progressDiv.style.width = '100%';
       progressDiv.setAttribute('aria-valuenow', 100);
       titleDiv.innerHTML = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
+      inbytesSpan.innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
+      outbytesSpan.innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
+      filesSpan.innerText = Joomla.Update.stat_files;
 
       Joomla.Update.finalizeUpdate();
 
@@ -148,9 +154,9 @@ Joomla.Update = window.Joomla.Update || {
 
     progressDiv.innerText = `${Joomla.Update.stat_percent.toFixed(1)}%`;
 
-    document.getElementById('extbytesin').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
-    document.getElementById('extbytesout').innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
-    document.getElementById('extfiles').innerText = Joomla.Update.stat_files;
+    inbytesSpan.innerText = Joomla.Update.formatBytes(Joomla.Update.stat_inbytes);
+    outbytesSpan.innerText = Joomla.Update.formatBytes(Joomla.Update.stat_outbytes);
+    filesSpan.innerText = Joomla.Update.stat_files;
 
     // This is required so we can get outside the scope of the previous XHR's success handler.
     window.setTimeout(() => {


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/35388#issuecomment-907789132 .

### Summary of Changes

- Update UI at the beginning with zero values for bytes and files.

- Don't use formatted values internally e.g. for calculations but do the formatting when updating the UI

- Move the return when done to below the UI update so you can see the final values at the end, too.

### Testing Instructions

Test https://github.com/joomla/joomla-cms/pull/35388 without and with the changes proposed here.

### Actual result BEFORE applying this Pull Request

No bytes and files values shown.

### Expected result AFTER applying this Pull Request

Bytes and files values shown and updated.

### Documentation Changes Required

None.