### PR TITLE
[CMS PR 37811] SQL code style and consistency fixed and real null date for last_used

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.2.0-2022-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.2.0-2022-05-15.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `#__user_tfa` (
   `title` varchar(255) NOT NULL DEFAULT '',
   `method` varchar(100) NOT NULL DEFAULT '',
   `default` tinyint NOT NULL DEFAULT 0,
-  `options` longtext NOT NULL,
+  `options` mediumtext NOT NULL,
   `created_on` datetime NOT NULL,
   `last_used` datetime,
   PRIMARY KEY (`id`),

--- a/administrator/components/com_admin/sql/updates/mysql/4.2.0-2022-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.2.0-2022-05-15.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS `#__user_tfa` (
   `id` int NOT NULL AUTO_INCREMENT,
   `user_id` int unsigned NOT NULL,
   `title` varchar(255) NOT NULL DEFAULT '',
-  `method` varchar(100) NOT NULL DEFAULT '',
+  `method` varchar(100) NOT NULL,
   `default` tinyint NOT NULL DEFAULT 0,
   `options` mediumtext NOT NULL,
   `created_on` datetime NOT NULL,

--- a/administrator/components/com_admin/sql/updates/mysql/4.2.0-2022-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.2.0-2022-05-15.sql
@@ -2,15 +2,16 @@
 -- Create the new table for captive TFA
 --
 CREATE TABLE IF NOT EXISTS `#__user_tfa` (
-  `id`         SERIAL,
-  `user_id`    int unsigned NOT NULL,
-  `title`      VARCHAR(255)    NOT NULL,
-  `method`     VARCHAR(100)    NOT NULL,
-  `default`    TINYINT(1)      NOT NULL DEFAULT 0,
-  `options`    LONGTEXT        NULL,
-  `created_on` DATETIME        NULL,
-  `last_used`  DATETIME        NULL,
-  INDEX `#__user_tfa_user` (`user_id`)
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int unsigned NOT NULL,
+  `title` varchar(255) NOT NULL DEFAULT '',
+  `method` varchar(100) NOT NULL DEFAULT '',
+  `default` tinyint NOT NULL DEFAULT 0,
+  `options` longtext NOT NULL,
+  `created_on` datetime NOT NULL,
+  `last_used` datetime,
+  PRIMARY KEY (`id`),
+  KEY `idx_user_id` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci COMMENT='Two Factor Authentication settings';
 
 --

--- a/administrator/components/com_admin/sql/updates/postgresql/4.2.0-2022-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.2.0-2022-05-15.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS "#__user_tfa" (
   "id" serial NOT NULL,
   "user_id" bigint NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  "method" varchar(100) DEFAULT '' NOT NULL,
+  "method" varchar(100) NOT NULL,
   "default" smallint DEFAULT 0 NOT NULL,
   "options" text NOT NULL,
   "created_on" timestamp without time zone NOT NULL,

--- a/administrator/components/com_admin/sql/updates/postgresql/4.2.0-2022-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.2.0-2022-05-15.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS "#__user_tfa" (
   PRIMARY KEY ("id")
 );
 
-CREATE INDEX "#__user_tfa_idx_user_id" ON "#__user_tfa" ("user_id");
+CREATE INDEX "#__user_tfa_idx_user_id" ON "#__user_tfa" ("user_id") /** CAN FAIL **/;
 
 COMMENT ON TABLE "#__user_tfa" IS 'Two Factor Authentication settings';
 

--- a/administrator/components/com_admin/sql/updates/postgresql/4.2.0-2022-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.2.0-2022-05-15.sql
@@ -3,13 +3,13 @@
 --
 CREATE TABLE IF NOT EXISTS "#__user_tfa" (
   "id" serial NOT NULL,
-  "user_id" bigint DEFAULT 0 NOT NULL,
+  "user_id" bigint NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
   "method" varchar(100) DEFAULT '' NOT NULL,
-  "default" smallint DEFAULT 0,
+  "default" smallint DEFAULT 0 NOT NULL,
   "options" text NOT NULL,
   "created_on" timestamp without time zone NOT NULL,
-  "last_used" timestamp without time zone NOT NULL,
+  "last_used" timestamp without time zone,
   PRIMARY KEY ("id")
 );
 

--- a/administrator/components/com_users/tmpl/methods/list.php
+++ b/administrator/components/com_users/tmpl/methods/list.php
@@ -95,7 +95,11 @@ $model = $this->getModel();
 											<?php echo Text::sprintf('COM_USERS_TFA_LBL_CREATEDON', $model->formatRelative($record->created_on)) ?>
 										</span>
 										<span class="com-users-methods-list-method-record-lastused-date w-50">
-											<?php echo Text::sprintf('COM_USERS_TFA_LBL_LASTUSED', $model->formatRelative($record->last_used)) ?>
+											<?php if ($record->last_used === null) : ?>
+												<?php echo Text::sprintf('COM_USERS_TFA_LBL_LASTUSED', Text::_('JNEVER')); ?>
+											<?php else : ?>
+												<?php echo Text::sprintf('COM_USERS_TFA_LBL_LASTUSED', $model->formatRelative($record->last_used)) ?>
+											<?php endif; ?>
 										</span>
 									</div>
 

--- a/components/com_users/tmpl/methods/list.php
+++ b/components/com_users/tmpl/methods/list.php
@@ -95,7 +95,11 @@ $model = $this->getModel();
 											<?php echo Text::sprintf('COM_USERS_TFA_LBL_CREATEDON', $model->formatRelative($record->created_on)) ?>
 										</span>
 										<span class="com-users-methods-list-method-record-lastused-date w-50">
-											<?php echo Text::sprintf('COM_USERS_TFA_LBL_LASTUSED', $model->formatRelative($record->last_used)) ?>
+											<?php if ($record->last_used === null) : ?>
+												<?php echo Text::sprintf('COM_USERS_TFA_LBL_LASTUSED', Text::_('JNEVER')); ?>
+											<?php else : ?>
+												<?php echo Text::sprintf('COM_USERS_TFA_LBL_LASTUSED', $model->formatRelative($record->last_used)) ?>
+											<?php endif; ?>
 										</span>
 									</div>
 

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -1028,7 +1028,7 @@ CREATE TABLE IF NOT EXISTS `#__user_tfa` (
   `title` varchar(255) NOT NULL DEFAULT '',
   `method` varchar(100) NOT NULL DEFAULT '',
   `default` tinyint NOT NULL DEFAULT 0,
-  `options` longtext NOT NULL,
+  `options` mediumtext NOT NULL,
   `created_on` datetime NOT NULL,
   `last_used` datetime,
   PRIMARY KEY (`id`),

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -1023,15 +1023,16 @@ CREATE TABLE IF NOT EXISTS `#__user_profiles` (
 --
 
 CREATE TABLE IF NOT EXISTS `#__user_tfa` (
-  `id`         SERIAL,
-  `user_id`    int unsigned NOT NULL,
-  `title`      VARCHAR(255)    NOT NULL,
-  `method`     VARCHAR(100)    NOT NULL,
-  `default`    TINYINT(1)      NOT NULL DEFAULT 0,
-  `options`    LONGTEXT        NULL,
-  `created_on` DATETIME        NULL,
-  `last_used`  DATETIME        NULL,
-  INDEX `#__user_tfa_user` (`user_id`)
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int unsigned NOT NULL,
+  `title` varchar(255) NOT NULL DEFAULT '',
+  `method` varchar(100) NOT NULL DEFAULT '',
+  `default` tinyint NOT NULL DEFAULT 0,
+  `options` longtext NOT NULL,
+  `created_on` datetime NOT NULL,
+  `last_used` datetime,
+  PRIMARY KEY (`id`),
+  KEY `idx_user_id` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci COMMENT='Two Factor Authentication settings';
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -1026,7 +1026,7 @@ CREATE TABLE IF NOT EXISTS `#__user_tfa` (
   `id` int NOT NULL AUTO_INCREMENT,
   `user_id` int unsigned NOT NULL,
   `title` varchar(255) NOT NULL DEFAULT '',
-  `method` varchar(100) NOT NULL DEFAULT '',
+  `method` varchar(100) NOT NULL,
   `default` tinyint NOT NULL DEFAULT 0,
   `options` mediumtext NOT NULL,
   `created_on` datetime NOT NULL,

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -1045,14 +1045,14 @@ COMMENT ON TABLE "#__user_profiles" IS 'Simple user profile storage table';
 
 CREATE TABLE IF NOT EXISTS "#__user_tfa" (
   "id" serial NOT NULL,
-  "user_id" bigint DEFAULT 0 NOT NULL,
+  "user_id" bigint NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
   "method" varchar(100) DEFAULT '' NOT NULL,
-  "default" smallint DEFAULT 0,
+  "default" smallint DEFAULT 0 NOT NULL,
   "options" text NOT NULL,
   "created_on" timestamp without time zone NOT NULL,
-  "last_used" timestamp without time zone NOT NULL,
-PRIMARY KEY ("id")
+  "last_used" timestamp without time zone,
+  PRIMARY KEY ("id")
 );
 
 CREATE INDEX "#__user_tfa_idx_user_id" ON "#__user_tfa" ("user_id");

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -1047,7 +1047,7 @@ CREATE TABLE IF NOT EXISTS "#__user_tfa" (
   "id" serial NOT NULL,
   "user_id" bigint NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  "method" varchar(100) DEFAULT '' NOT NULL,
+  "method" varchar(100) NOT NULL,
   "default" smallint DEFAULT 0 NOT NULL,
   "options" text NOT NULL,
   "created_on" timestamp without time zone NOT NULL,

--- a/language/en-GB/joomla.ini
+++ b/language/en-GB/joomla.ini
@@ -88,6 +88,7 @@ JINVALID_TOKEN_NOTICE="The security token did not match. The request was aborted
 JLOGIN="Log in"
 JLOGOUT="Log out"
 JMONTH="Month"
+JNEVER="Never"
 JNEW="New"
 JNEXT="Next"
 JNEXT_TITLE="Next article: %s"

--- a/libraries/src/Application/TwoFactorAuthenticationAware.php
+++ b/libraries/src/Application/TwoFactorAuthenticationAware.php
@@ -416,7 +416,7 @@ trait TwoFactorAuthenticationAware
 							'method'     => 'totp',
 							'default'    => 0,
 							'created_on' => Date::getInstance()->toSql(),
-							'last_used'  => $db->getNullDate(),
+							'last_used'  => null,
 							'options'    => ['key' => $config['code']],
 						]
 					);
@@ -432,7 +432,7 @@ trait TwoFactorAuthenticationAware
 							'method'     => 'yubikey',
 							'default'    => 0,
 							'created_on' => Date::getInstance()->toSql(),
-							'last_used'  => $db->getNullDate(),
+							'last_used'  => null,
 							'options'    => ['id' => $config['yubikey']],
 						]
 					);
@@ -466,7 +466,7 @@ trait TwoFactorAuthenticationAware
 					'method'     => 'backupcodes',
 					'default'    => 0,
 					'created_on' => Date::getInstance()->toSql(),
-					'last_used'  => $db->getNullDate(),
+					'last_used'  => null,
 					'options'    => @json_decode($otep, true),
 				]
 			);


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/37811 .

### Summary of Changes

- Adjust code style in SQL scripts to the core.
- Have not null constraints and default values consistent between the 2 database types for the new table.
- Let data types, default values and not null constraints be consistent with the rest of the core.
- Do not use display width 1 for tinyint on MySQL since that does not serve any purpose and is deprecated in MySQL 8. See https://github.com/joomla/joomla-cms/pull/32606 for the explanation.
- Add the "CAN FAIL" installer hint to the update SQL script for PostgreSQL in case if the index already exists from a previous update attempt.
- Allow real null values for datetimes (here only the last_used).

### Testing Instructions

Code review.