### PR TITLE
[CMS PR 38121] Use uppercase for array key and language string key

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -155,10 +155,13 @@ class ExtensionAdapter extends UpdateAdapter
 							}
 						}
 
+						// $supportedDbs has uppercase keys because they are XML attribute names
+						$dbTypeUcase = strtoupper($dbType);
+
 						// Do we have an entry for the database?
-						if (in_array($dbType, array_map('strtolower', array_keys($supportedDbs))))
+						if (\array_key_exists($dbTypeUcase, $supportedDbs))
 						{
-							$minimumVersion = $supportedDbs[$dbType];
+							$minimumVersion = $supportedDbs[$dbTypeUcase];
 							$dbMatch        = version_compare($dbVersion, $minimumVersion, '>=');
 
 							if (!$dbMatch)
@@ -168,7 +171,7 @@ class ExtensionAdapter extends UpdateAdapter
 									'JLIB_INSTALLER_AVAILABLE_UPDATE_DB_MINIMUM',
 									$this->currentUpdate->name,
 									$this->currentUpdate->version,
-									Text::_($db->name),
+									Text::_('JLIB_DB_SERVER_TYPE_' . $dbTypeUcase),
 									$dbVersion,
 									$minimumVersion
 								);
@@ -183,7 +186,7 @@ class ExtensionAdapter extends UpdateAdapter
 								'JLIB_INSTALLER_AVAILABLE_UPDATE_DB_TYPE',
 								$this->currentUpdate->name,
 								$this->currentUpdate->version,
-								Text::_('JLIB_DB_SERVER_TYPE_' . $dbType)
+								Text::_('JLIB_DB_SERVER_TYPE_' . $dbTypeUcase)
 							);
 
 							Factory::getApplication()->enqueueMessage($dbMsg, 'warning');


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/38121 .

### Summary of Changes

The `$supportedDbs` array is given as an array of XML attributes and so the keys are in uppercase (it seems the XML parser does that itself. I could verify that with some debug output. Therefore the version check currently fails in the CMS PR.

The new language strings from the CMS PR should also be applied to the alert message when the version check fails.

### Testing Instructions

For testing I have created a few update sites:

- For testing as described in the CMS PR use https://test5.richard-fath.de/test_pr-38121.xml

- For database type being not supported https://test5.richard-fath.de/test_pr-38121_test-2.xml - This has `<supported_databases oracle="12.0" />`, so the used DB will not be supported for sure.

- For database version being not supported https://test5.richard-fath.de/test_pr-38121_test-3.xml - This has `<supported_databases mysql="10.0.0" mariadb="20.0"  postgresql="20.0" />`, so the DB will be a too old version of a supported type.

Just change the `location` column of the record with name 'Social Magick Updates' in the `#__update_sites` table to the mentioned URL and run the search for updates.

### Actual result BEFORE applying this Pull Request

The test with the database type being supported but the version being too old fails.

### Expected result AFTER applying this Pull Request

The test with the database type being supported but the version being too old succeeds.

### Documentation Changes Required

None.