### PR TITLE
[CMS PR 38707] Fix regular expressions

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -21,21 +21,21 @@ Joomla = window.Joomla || {};
     }
 
     // Make sure this is a .zip package based on its file extension and on its content type
-    if (!file.name.match(/.zip$/i) || (file.type !== 'application/zip' && file.type !== 'application/x-zip-compressed')) {
+    if (!file.name.match(/\.zip$/i) || (file.type !== 'application/zip' && file.type !== 'application/x-zip-compressed')) {
       Joomla.renderMessages({ error: [Joomla.Text._('COM_JOOMLAUPDATE_VIEW_UPLOAD_ERROR_NOTZIP')] });
 
       return;
     }
 
     // Make sure this is not a Full Package based on its name
-    if (!form.install_package.value.match(/^Joomla_-(.*)-Full_Package.zip$/i)) {
+    if (form.install_package.value.match(/Joomla_(.*)-Full_Package\.zip$/i)) {
       Joomla.renderMessages({ error: [Joomla.Text._('COM_JOOMLAUPDATE_VIEW_UPLOAD_ERROR_FULLINSTALLATION_PREUPLOAD')] });
 
       return;
     }
 
     // Make sure this is an Upgrade Package based on its name
-    if (!form.install_package.value.match(/^Joomla_-(.*)-(Upgrade|Update|Patch)_Package.zip$/i)) {
+    if (!form.install_package.value.match(/Joomla_(.*)-(Upgrade|Update|Patch)_Package\.zip$/i)) {
       Joomla.renderMessages({ error: [Joomla.Text._('COM_JOOMLAUPDATE_VIEW_UPLOAD_ERROR_NOTUPGRADE')] });
 
       return;


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/38707 .

### Summary of Changes

- Escape real dot before extension. A dot in a regex means „any character“, but here we want to match a real dot only.
- Remove start of string anchor `^` because the file has a path (even if a dummy path, e.g. `C:\fakepath\` on Windows).
- Remove wrong negation `!` for matching the full package.
- Remove wrong dash after the `Joomla_`.

I have tested my changes of course.